### PR TITLE
Refactor issue search functionality to support multiple organizations

### DIFF
--- a/app/api/github/issues/route.ts
+++ b/app/api/github/issues/route.ts
@@ -10,19 +10,20 @@ export async function GET(request: Request) {
 
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('query') || '';
-    const organization = searchParams.get('org') || '';
+    const orgs = searchParams.get('orgs') || '';
 
     const accessToken = session.accessToken as string;
     
     // Build the GitHub search query
-    let searchQuery = 'is:issue';
+    let searchQuery = 'archived:false is:open is:issue';
+    if (orgs) {
+      orgs.split(',').forEach(org => {
+        searchQuery += ` org:${org}`;
+      });
+    }
     if (query) {
       searchQuery += ` ${query}`;
     }
-    if (organization) {
-      searchQuery += ` org:${organization}`;
-    }
-    searchQuery += ' involves:@me'; // Only issues that involve the user
     
     // Fetch issues based on search query
     const response = await fetch(`https://api.github.com/search/issues?q=${encodeURIComponent(searchQuery)}&sort=updated&order=desc`, {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,15 +26,13 @@ export default function Home() {
     };
   }, []);
 
-  const handleSearch = async (query: string, organization: string) => {
+  const handleSearch = async (query: string, orgs: string[]) => {
     setIsSearching(true);
     setHasSearched(true);
     setSearchError(null);
 
     try {
-      // If organization is "all", pass empty string to the API
-      const orgParam = organization === "all" ? "" : organization;
-      const data = await searchIssues(query, orgParam);
+      const data = await searchIssues(query, orgs);
       setSearchResults(data);
     } catch (error) {
       console.error("Error searching issues:", error);

--- a/components/issue-list.tsx
+++ b/components/issue-list.tsx
@@ -3,6 +3,7 @@
 import { useTimerStore } from "@/store/timer-store";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import Image from "next/image";
 
 interface Issue {
   id: number;
@@ -13,7 +14,12 @@ interface Issue {
   repository_url: string;
   user: {
     login: string;
+    avatar_url?: string;
   };
+  assignees?: {
+    login: string;
+    avatar_url?: string;
+  }[];
 }
 
 interface IssueListProps {
@@ -78,16 +84,16 @@ export function IssueList({ issues, loading }: IssueListProps) {
           // Extract repository name from URL
           const repoUrl = issue.repository_url;
           const repoName = repoUrl.split('/').slice(-2).join('/');
-          
+
           // Format date
           const updatedDate = new Date(issue.updated_at).toLocaleDateString();
-          
+
           return (
             <div
               key={issue.id}
               className="flex justify-between items-center p-4 border rounded-md hover:bg-muted/50 transition-colors"
             >
-              <div className="space-y-1">
+              <div className="space-y-2">
                 <h3 className="font-medium">
                   <a
                     href={issue.html_url}
@@ -98,7 +104,7 @@ export function IssueList({ issues, loading }: IssueListProps) {
                     {issue.title}
                   </a>
                 </h3>
-                <div className="text-sm text-muted-foreground flex gap-2">
+                <div className="text-sm text-muted-foreground flex flex-wrap gap-2 items-center">
                   <span>{repoName}</span>
                   <span>•</span>
                   <span>
@@ -110,6 +116,41 @@ export function IssueList({ issues, loading }: IssueListProps) {
                   </span>
                   <span>•</span>
                   <span>Updated {updatedDate}</span>
+                </div>
+                <div className="mt-2 text-muted-foreground flex items-center gap-4">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-muted-foreground">Created By</span>
+                    <div className="flex items-center gap-1.5">
+                      {issue.user.avatar_url && (
+                        <Image
+                          src={issue.user.avatar_url}
+                          alt={`${issue.user.login}'s avatar`}
+                          width={20}
+                          height={20}
+                          className="rounded-full object-cover"
+                        />
+                      )}
+                    </div>
+                  </div>
+                  <span>•</span>
+                  {issue.assignees && issue.assignees.length > 0 ? (
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-muted-foreground">Assigned To</span>
+                      {issue.assignees.map((assignee, index) => (
+                        <div key={index} className="flex items-center gap-1.5">
+                          {assignee.avatar_url && (
+                            <Image
+                              src={assignee.avatar_url}
+                              alt={`${assignee.login}'s avatar`}
+                              width={20}
+                              height={20}
+                              className="rounded-full object-cover"
+                            />
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : <span className="text-sm text-muted-foreground">No Assignees</span>}
                 </div>
               </div>
               <button

--- a/components/issue-list.tsx
+++ b/components/issue-list.tsx
@@ -4,6 +4,12 @@ import { useTimerStore } from "@/store/timer-store";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import Image from "next/image";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { CircleDot } from "lucide-react";
 
 interface Issue {
   id: number;
@@ -37,7 +43,6 @@ export function IssueList({ issues, loading }: IssueListProps) {
       url: issue.html_url,
     });
   };
-
   if (loading) {
     return (
       <Card>
@@ -46,7 +51,10 @@ export function IssueList({ issues, loading }: IssueListProps) {
         </CardHeader>
         <CardContent className="space-y-4">
           {Array.from({ length: 5 }).map((_, index) => (
-            <div key={index} className="flex justify-between items-center p-4 border rounded-md">
+            <div
+              key={index}
+              className="flex justify-between items-center p-4 border rounded-md"
+            >
               <div className="space-y-2">
                 <Skeleton className="h-4 w-[250px]" />
                 <Skeleton className="h-3 w-[200px]" />
@@ -83,7 +91,7 @@ export function IssueList({ issues, loading }: IssueListProps) {
         {issues.map((issue) => {
           // Extract repository name from URL
           const repoUrl = issue.repository_url;
-          const repoName = repoUrl.split('/').slice(-2).join('/');
+          const repoName = repoUrl.split("/").slice(-2).join("/");
 
           // Format date
           const updatedDate = new Date(issue.updated_at).toLocaleDateString();
@@ -94,7 +102,18 @@ export function IssueList({ issues, loading }: IssueListProps) {
               className="flex justify-between items-center p-4 border rounded-md hover:bg-muted/50 transition-colors"
             >
               <div className="space-y-2">
-                <h3 className="font-medium">
+                <h3 className="font-medium flex gap-x-2 items-center">
+                  <span>
+                    {issue.state === "open" ? (
+                      <span className="text-green-600 dark:text-green-400">
+                        <CircleDot size={16} />
+                      </span>
+                    ) : (
+                      <span className="text-red-600 dark:text-red-400">
+                        <CircleDot size={16} />
+                      </span>
+                    )}
+                  </span>
                   <a
                     href={issue.html_url}
                     target="_blank"
@@ -106,38 +125,17 @@ export function IssueList({ issues, loading }: IssueListProps) {
                 </h3>
                 <div className="text-sm text-muted-foreground flex flex-wrap gap-2 items-center">
                   <span>{repoName}</span>
-                  <span>•</span>
-                  <span>
-                    {issue.state === "open" ? (
-                      <span className="text-green-600 dark:text-green-400">Open</span>
-                    ) : (
-                      <span className="text-red-600 dark:text-red-400">Closed</span>
-                    )}
-                  </span>
-                  <span>•</span>
+                </div>
+                <div className="text-sm text-muted-foreground flex flex-wrap gap-2 items-center">
                   <span>Updated {updatedDate}</span>
                 </div>
-                <div className="mt-2 text-muted-foreground flex items-center gap-4">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm text-muted-foreground">Created By</span>
-                    <div className="flex items-center gap-1.5">
-                      {issue.user.avatar_url && (
-                        <Image
-                          src={issue.user.avatar_url}
-                          alt={`${issue.user.login}'s avatar`}
-                          width={20}
-                          height={20}
-                          className="rounded-full object-cover"
-                        />
-                      )}
-                    </div>
-                  </div>
-                  <span>•</span>
-                  {issue.assignees && issue.assignees.length > 0 ? (
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm text-muted-foreground">Assigned To</span>
-                      {issue.assignees.map((assignee, index) => (
-                        <div key={index} className="flex items-center gap-1.5">
+              </div>
+              <div className="flex flex-col h-20 justify-between items-end">
+                {issue.assignees && issue.assignees.length > 0 && (
+                  <div className="flex items-center gap-1.5">
+                    {issue.assignees.map((assignee, index) => (
+                      <Tooltip key={index}>
+                        <TooltipTrigger>
                           {assignee.avatar_url && (
                             <Image
                               src={assignee.avatar_url}
@@ -147,18 +145,24 @@ export function IssueList({ issues, loading }: IssueListProps) {
                               className="rounded-full object-cover"
                             />
                           )}
-                        </div>
-                      ))}
-                    </div>
-                  ) : <span className="text-sm text-muted-foreground">No Assignees</span>}
-                </div>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <span>{assignee.login}</span>
+                        </TooltipContent>
+                      </Tooltip>
+                    ))}
+                  </div>
+                )}
+
+                <div className="flex-1"></div>
+
+                <button
+                  onClick={() => handleStartTracking(issue)}
+                  className="px-3 py-1 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
+                >
+                  Track Time
+                </button>
               </div>
-              <button
-                onClick={() => handleStartTracking(issue)}
-                className="px-3 py-1 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
-              >
-                Track Time
-              </button>
             </div>
           );
         })}

--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -114,15 +114,13 @@ export function useGithubApi() {
   };
 
   // Search issues
-  const searchIssues = async (query: string, organization: string) => {
+  const searchIssues = async (query: string, orgs: string[]) => {
     setIsSearching(true);
     setHasSearched(true);
     setSearchError(null);
     
     try {
-      // If organization is "all", pass empty string to the API
-      const orgParam = organization === "all" ? "" : organization;
-      const data = await apiServices.searchIssues(query, orgParam);
+      const data = await apiServices.searchIssues(query, orgs);
       setSearchResults(data);
       return data;
     } catch (error) {

--- a/lib/api-services.ts
+++ b/lib/api-services.ts
@@ -54,10 +54,10 @@ export async function fetchUserPullRequests() {
   return await response.json();
 }
 
-export async function searchIssues(query: string, organization: string) {
+export async function searchIssues(query: string, orgs: string[]) {
   const params = new URLSearchParams();
   if (query) params.append("query", query);
-  if (organization) params.append("org", organization);
+  if (orgs) params.append("orgs", orgs.join(","));
 
   const response = await fetch(`/api/github/issues?${params.toString()}`);
   if (!response.ok) throw new Error("Failed to search issues");


### PR DESCRIPTION
#### **Enhancement: Improved Issue Search Across Multiple Organizations**

This PR enhances the issue search functionality by:
- **Removing the default organization filter** to allow searching across multiple organizations.
- **Updating related components and API calls** to support organization-agnostic queries.

#### **Impact & Benefits**
- Users can now search for issues across all accessible organizations without restrictions.
- Improved flexibility in filtering and finding relevant issues.

#### **Pro Tip** 💡
If you want to filter issues assigned to you, include in the search query:
```
assignee:{your_github_handle}
```
Example:
```
assignee:atitoa93
```

#### **Testing & Validation**
- Ensure searches return expected results across multiple organizations.
- Verify that removing the organization filter does not break existing queries.
- Confirm API calls handle organization-agnostic searches correctly. 