### PR TITLE
feat(timer): implement multi-issue tracking support

### DIFF
--- a/components/task-timer.tsx
+++ b/components/task-timer.tsx
@@ -6,11 +6,19 @@ import { Pause, Play, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { ExternalLink } from "@/components/ui/external-link";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown } from "lucide-react";
 
 export function TaskTimer() {
-  const { isRunning, elapsedTime, activeIssue, toggleTimer, stopTracking } =
+  const { issues, activeIssueId, toggleTimer, stopTracking, switchToIssue } =
     useTimerStore();
 
+  const activeIssue = issues.find(issue => issue.id === activeIssueId);
   if (!activeIssue) return null;
 
   return (
@@ -20,25 +28,46 @@ export function TaskTimer() {
         <div className="hidden md:flex flex-col items-start pr-2">
           <div className="text-xs text-muted-foreground">Tracking</div>
           <div className="flex items-center justify-between">
-            <div className="text-sm font-medium truncate max-w-[200px]">
-              {activeIssue.title}
-            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="h-auto p-0">
+                  <div className="text-sm font-medium truncate max-w-[200px]">
+                    {activeIssue.title}
+                  </div>
+                  <ChevronDown className="h-4 w-4 ml-1" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {issues.map((issue) => (
+                  <DropdownMenuItem
+                    key={issue.id}
+                    onClick={() => switchToIssue(issue.id)}
+                    className="flex items-center justify-between"
+                  >
+                    <span className="truncate max-w-[200px]">{issue.title}</span>
+                    <span className="text-xs text-muted-foreground ml-2">
+                      {formatTime(issue.elapsedTime)}
+                    </span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
             <ExternalLink href={activeIssue.url} title="Open in GitHub" />
           </div>
         </div>
 
         <div className="flex items-center pl-2">
           <div className="text-lg font-mono w-20">
-            {formatTime(elapsedTime)}
+            {formatTime(activeIssue.elapsedTime)}
           </div>
 
           <Button
             variant="ghost"
             size="icon"
             onClick={toggleTimer}
-            aria-label={isRunning ? "Pause timer" : "Start timer"}
+            aria-label={activeIssue.isRunning ? "Pause timer" : "Start timer"}
           >
-            {isRunning ? (
+            {activeIssue.isRunning ? (
               <Pause className="h-4 w-4" />
             ) : (
               <Play className="h-4 w-4" />

--- a/components/timer-initializer.tsx
+++ b/components/timer-initializer.tsx
@@ -4,18 +4,20 @@ import { useEffect, useRef } from "react";
 import { useTimerStore } from "@/store/timer-store";
 
 export function TimerInitializer() {
-  const { isRunning, elapsedTime, setElapsedTime } = useTimerStore();
+  const { issues, activeIssueId, updateIssueTime } = useTimerStore();
   const startTimeRef = useRef<number | null>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Handle timer logic
   useEffect(() => {
-    if (isRunning) {
-      startTimeRef.current = Date.now() - elapsedTime * 1000;
+    const activeIssue = issues.find(issue => issue.id === activeIssueId);
+
+    if (activeIssue?.isRunning) {
+      startTimeRef.current = Date.now() - activeIssue.elapsedTime * 1000;
       intervalRef.current = setInterval(() => {
         if (startTimeRef.current) {
           const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
-          setElapsedTime(elapsed);
+          updateIssueTime(activeIssueId!, elapsed);
         }
       }, 1000);
     } else if (intervalRef.current) {
@@ -27,7 +29,7 @@ export function TimerInitializer() {
         clearInterval(intervalRef.current);
       }
     };
-  }, [isRunning, elapsedTime, setElapsedTime]);
+  }, [issues, activeIssueId, updateIssueTime]);
 
   // This component doesn't render anything
   return null;

--- a/components/work-session-modal.tsx
+++ b/components/work-session-modal.tsx
@@ -19,18 +19,18 @@ import { AlertCircle } from "lucide-react";
 export function WorkSessionModal() {
   const {
     isCommentModalOpen,
-    activeIssue,
-    nextIssue,
-    elapsedTime,
+    issues,
+    activeIssueId,
     cancelComment,
     submitComment,
-    isSwitchingIssues,
     discardTracking
   } = useTimerStore();
 
   const [comment, setComment] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const activeIssue = issues.find(issue => issue.id === activeIssueId);
 
   const handleSubmit = async () => {
     if (!comment.trim()) return;
@@ -63,89 +63,42 @@ export function WorkSessionModal() {
 
   if (!activeIssue) return null;
 
-  // Customize title and descriptions based on whether we're switching issues
-  const title = isSwitchingIssues
-    ? "Complete current work session"
-    : "Submit work session details";
-
-  const description = isSwitchingIssues
-    ? `Before tracking "${
-        nextIssue?.title
-      }", please describe the work you completed on "${
-        activeIssue.title
-      }" (${formatTime(elapsedTime)}).`
-    : `Describe the work you completed during this session (${formatTime(
-        elapsedTime
-      )}).`;
-
-  const submissionNote = isSwitchingIssues
-    ? "Your comment will be posted to the current issue and tracking will begin on the new issue."
-    : "This will be posted as a comment to the GitHub issue.";
-
   return (
-    <Dialog
-      open={isCommentModalOpen}
-      onOpenChange={(open) => !open && handleCancel()}
-    >
-      <DialogContent className="sm:max-w-[500px]">
+    <Dialog open={isCommentModalOpen} onOpenChange={() => handleCancel()}>
+      <DialogContent>
         <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
+          <DialogTitle>Submit work session details</DialogTitle>
           <DialogDescription>
-            {description}
-            <br />
-            {submissionNote}
+            Describe the work you completed during this session ({formatTime(activeIssue.elapsedTime)}).
           </DialogDescription>
         </DialogHeader>
 
         {error && (
-          <Alert variant="destructive" className="my-2">
+          <Alert variant="destructive">
             <AlertCircle className="h-4 w-4" />
             <AlertTitle>Error</AlertTitle>
             <AlertDescription>{error}</AlertDescription>
           </Alert>
         )}
 
-        <div className="py-4">
-          <Textarea
-            placeholder="Describe your work or progress..."
-            className="min-h-[150px]"
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-            disabled={isSubmitting}
-          />
-        </div>
+        <Textarea
+          placeholder="What did you work on?"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          className="min-h-[100px]"
+        />
 
-        <DialogFooter className="flex justify-between">
-          <div>
-            {!isSwitchingIssues && (
-              <Button
-                variant="destructive"
-                onClick={handleDiscard}
-                disabled={isSubmitting}
-              >
-                Discard
-              </Button>
-            )}
-          </div>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              onClick={handleCancel}
-              disabled={isSubmitting}
-            >
-              {isSwitchingIssues ? "Continue Current Issue" : "Cancel"}
-            </Button>
-            <Button
-              onClick={handleSubmit}
-              disabled={!comment.trim() || isSubmitting}
-            >
-              {isSubmitting
-                ? "Submitting..."
-                : isSwitchingIssues
-                ? "Submit & Switch Issues"
-                : "Submit Comment"}
-            </Button>
-          </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={handleDiscard}
+            disabled={isSubmitting}
+          >
+            Discard
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? "Submitting..." : "Submit"}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Description
This PR introduces the ability to track multiple GitHub issues simultaneously. Users can now switch between issues while preserving individual timers, making it easier to manage work across multiple tasks.

## Key Features
- 🔄 Track multiple issues at once
- ⏯️ Pause/resume individual issue timers
- 🔀 Switch between issues via dropdown menu
- ⏱️ Preserve elapsed time for each issue
- 💾 Persist tracked issues across sessions

## Technical Changes
- Refactored timer store to support multiple issues
- Added new actions for issue switching and time management
- Updated UI components to handle multi-issue workflow
- Implemented dropdown menu for issue switching
- Modified timer initialization logic for multi-issue support

## User Experience
Users can now:
1. Start tracking multiple issues
2. Switch between issues using the dropdown menu
3. See elapsed time for all tracked issues
4. Pause/resume any issue independently
5. Submit work sessions for any tracked issue

## Screenshot 
<img width="548" alt="image" src="https://github.com/user-attachments/assets/aef6b064-5a73-4f09-9453-a3fb7bf1e3d5" />
