### PR TITLE
feat: add tracked tickets list functionality

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,11 +7,12 @@ import { IssueSearch } from "@/components/issue-search";
 import { IssueList } from "@/components/issue-list";
 import { SidebarInset } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
+import { TicketHistory } from "@/components/ticket-history";
 
 export default function Home() {
-  const { 
-    searchResults, 
-    isSearching, 
+  const {
+    searchResults,
+    isSearching,
     hasSearched,
     setSearchResults,
     setIsSearching,
@@ -53,13 +54,21 @@ export default function Home() {
 
           <IssueSearch onSearch={handleSearch} />
 
-          {hasSearched && <IssueList issues={searchResults} loading={isSearching} />}
-
-          {!hasSearched && (
-            <div className="text-center py-16 text-muted-foreground">
-              Search for issues above to get started
+          <div className="grid grid-cols-2 gap-6 mt-8">
+            <div className="h-full">
+              <h2 className="text-2xl font-semibold mb-4">Search Results</h2>
+              {hasSearched ? (
+                <IssueList issues={searchResults} loading={isSearching} />
+              ) : (
+                <div className="text-center py-8 text-muted-foreground">
+                  Search for issues above to get started
+                </div>
+              )}
             </div>
-          )}
+            <div className="h-full">
+              <TicketHistory />
+            </div>
+          </div>
         </div>
       </SidebarInset>
     </div>

--- a/components/issue-list.tsx
+++ b/components/issue-list.tsx
@@ -9,24 +9,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { CircleDot } from "lucide-react";
-
-interface Issue {
-  id: number;
-  title: string;
-  html_url: string;
-  state: string;
-  updated_at: string;
-  repository_url: string;
-  user: {
-    login: string;
-    avatar_url?: string;
-  };
-  assignees?: {
-    login: string;
-    avatar_url?: string;
-  }[];
-}
+import { CircleDot, BookmarkIcon, BookmarkCheckIcon } from "lucide-react";
+import { Issue } from "@/types/github";
+import { useGithubStore } from "@/store/github-store";
+import { Button } from "@/components/ui/button";
 
 interface IssueListProps {
   issues: Issue[];
@@ -35,6 +21,9 @@ interface IssueListProps {
 
 export function IssueList({ issues, loading }: IssueListProps) {
   const { startTracking } = useTimerStore();
+  const { trackedTickets, addTrackedTicket, removeTrackedTicket } = useGithubStore();
+
+  const isTracked = (issue: Issue) => trackedTickets.some(ticket => ticket.id === issue.id);
 
   const handleStartTracking = (issue: Issue) => {
     startTracking({
@@ -42,7 +31,20 @@ export function IssueList({ issues, loading }: IssueListProps) {
       title: issue.title,
       url: issue.html_url,
     });
+    // Automatically add to tracked tickets when starting to track time
+    if (!isTracked(issue)) {
+      addTrackedTicket(issue);
+    }
   };
+
+  const handleTrackToggle = (issue: Issue) => {
+    if (isTracked(issue)) {
+      removeTrackedTicket(issue.id);
+    } else {
+      addTrackedTicket(issue);
+    }
+  };
+
   if (loading) {
     return (
       <Card>
@@ -156,12 +158,26 @@ export function IssueList({ issues, loading }: IssueListProps) {
 
                 <div className="flex-1"></div>
 
-                <button
-                  onClick={() => handleStartTracking(issue)}
-                  className="px-3 py-1 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
-                >
-                  Track Time
-                </button>
+                <div className="flex gap-2">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleTrackToggle(issue)}
+                    className="h-8 w-8"
+                  >
+                    {isTracked(issue) ? (
+                      <BookmarkCheckIcon className="h-4 w-4" />
+                    ) : (
+                      <BookmarkIcon className="h-4 w-4" />
+                    )}
+                  </Button>
+                  <Button
+                    onClick={() => handleStartTracking(issue)}
+                    className="h-8"
+                  >
+                    Track Time
+                  </Button>
+                </div>
               </div>
             </div>
           );

--- a/components/ticket-history.tsx
+++ b/components/ticket-history.tsx
@@ -1,0 +1,19 @@
+import { useGithubStore } from "@/store/github-store";
+import { IssueList } from "@/components/issue-list";
+
+export function TicketHistory() {
+    const { trackedTickets } = useGithubStore();
+
+    return (
+        <div className="h-full">
+            <h2 className="text-2xl font-semibold mb-4">Tracked Tickets</h2>
+            {trackedTickets.length > 0 ? (
+                <IssueList issues={trackedTickets} loading={false} />
+            ) : (
+                <div className="text-center py-8 text-muted-foreground">
+                    No tracked tickets yet. Click on a ticket to track it.
+                </div>
+            )}
+        </div>
+    );
+} 

--- a/store/github-store.ts
+++ b/store/github-store.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { Issue } from '@/types/github';
 
 interface User {
   name: string;
@@ -23,20 +25,6 @@ interface Repository {
   private: boolean;
   fork: boolean;
   updated_at: string;
-}
-
-interface Issue {
-  id: number;
-  number: number;
-  title: string;
-  html_url: string;
-  state: string;
-  updated_at: string;
-  repository_url: string;
-  user: {
-    login: string;
-    avatar_url: string;
-  };
 }
 
 interface Team {
@@ -80,25 +68,25 @@ interface GithubState {
   user: User | null;
   isLoadingUser: boolean;
   userError: string | null;
-  
+
   // Organizations 
   organizations: Organization[];
   isLoadingOrganizations: boolean;
   organizationsError: string | null;
-  
+
   // Organization resources
   repositories: Repository[];
   projects: Project[];
   teams: Team[];
   isLoadingOrgResources: boolean;
   orgResourcesError: string | null;
-  
+
   // User resources
   issues: Issue[];
   pullRequests: PullRequest[];
   isLoadingUserResources: boolean;
   userResourcesError: string | null;
-  
+
   // Team members
   teamMembers: TeamMember[];
   isLoadingTeamMembers: boolean;
@@ -109,6 +97,12 @@ interface GithubState {
   isSearching: boolean;
   hasSearched: boolean;
   searchError: string | null;
+
+  // Tracked tickets
+  trackedTickets: Issue[];
+  addTrackedTicket: (ticket: Issue) => void;
+  removeTrackedTicket: (ticketId: number) => void;
+  clearTrackedTickets: () => void;
 
   // Actions
   setUser: (user: User) => void;
@@ -139,90 +133,110 @@ interface GithubState {
   resetTeamMembersState: () => void;
 }
 
-export const useGithubStore = create<GithubState>((set) => ({
-  // User state
-  user: null,
-  isLoadingUser: false,
-  userError: null,
-  
-  // Organizations state
-  organizations: [],
-  isLoadingOrganizations: false,
-  organizationsError: null,
-  
-  // Organization resources state
-  repositories: [],
-  projects: [],
-  teams: [],
-  isLoadingOrgResources: false,
-  orgResourcesError: null,
-  
-  // User resources state
-  issues: [],
-  pullRequests: [],
-  isLoadingUserResources: false,
-  userResourcesError: null,
-  
-  // Team members state
-  teamMembers: [],
-  isLoadingTeamMembers: false,
-  teamMembersError: null,
-  
-  // Search results state
-  searchResults: [],
-  isSearching: false,
-  hasSearched: false,
-  searchError: null,
+export const useGithubStore = create<GithubState>()(
+  persist(
+    (set) => ({
+      // User state
+      user: null,
+      isLoadingUser: false,
+      userError: null,
 
-  // Actions
-  setUser: (user) => set({ user }),
-  setOrganizations: (organizations) => set({ organizations }),
-  setRepositories: (repositories) => set({ repositories }),
-  setProjects: (projects) => set({ projects }),
-  setTeams: (teams) => set({ teams }),
-  setIssues: (issues) => set({ issues }),
-  setPullRequests: (pullRequests) => set({ pullRequests }),
-  setTeamMembers: (teamMembers) => set({ teamMembers }),
-  setSearchResults: (searchResults) => set({ searchResults }),
-  setIsLoadingUser: (isLoadingUser) => set({ isLoadingUser }),
-  setIsLoadingOrganizations: (isLoadingOrganizations) => set({ isLoadingOrganizations }),
-  setIsLoadingOrgResources: (isLoadingOrgResources) => set({ isLoadingOrgResources }),
-  setIsLoadingUserResources: (isLoadingUserResources) => set({ isLoadingUserResources }),
-  setIsLoadingTeamMembers: (isLoadingTeamMembers) => set({ isLoadingTeamMembers }),
-  setIsSearching: (isSearching) => set({ isSearching }),
-  setHasSearched: (hasSearched) => set({ hasSearched }),
-  setUserError: (userError) => set({ userError }),
-  setOrganizationsError: (organizationsError) => set({ organizationsError }),
-  setOrgResourcesError: (orgResourcesError) => set({ orgResourcesError }),
-  setUserResourcesError: (userResourcesError) => set({ userResourcesError }),
-  setTeamMembersError: (teamMembersError) => set({ teamMembersError }),
-  setSearchError: (searchError) => set({ searchError }),
-  
-  resetSearchState: () => set({ 
-    searchResults: [], 
-    isSearching: false, 
-    hasSearched: false,
-    searchError: null 
-  }),
-  
-  resetOrgResourcesState: () => set({
-    repositories: [],
-    projects: [],
-    teams: [],
-    isLoadingOrgResources: false,
-    orgResourcesError: null
-  }),
-  
-  resetUserResourcesState: () => set({
-    issues: [],
-    pullRequests: [],
-    isLoadingUserResources: false,
-    userResourcesError: null
-  }),
+      // Organizations state
+      organizations: [],
+      isLoadingOrganizations: false,
+      organizationsError: null,
 
-  resetTeamMembersState: () => set({
-    teamMembers: [],
-    isLoadingTeamMembers: false,
-    teamMembersError: null
-  })
-}));
+      // Organization resources state
+      repositories: [],
+      projects: [],
+      teams: [],
+      isLoadingOrgResources: false,
+      orgResourcesError: null,
+
+      // User resources state
+      issues: [],
+      pullRequests: [],
+      isLoadingUserResources: false,
+      userResourcesError: null,
+
+      // Team members state
+      teamMembers: [],
+      isLoadingTeamMembers: false,
+      teamMembersError: null,
+
+      // Search results state
+      searchResults: [],
+      isSearching: false,
+      hasSearched: false,
+      searchError: null,
+
+      // Tracked tickets state
+      trackedTickets: [],
+
+      // Actions
+      setUser: (user) => set({ user }),
+      setOrganizations: (organizations) => set({ organizations }),
+      setRepositories: (repositories) => set({ repositories }),
+      setProjects: (projects) => set({ projects }),
+      setTeams: (teams) => set({ teams }),
+      setIssues: (issues) => set({ issues }),
+      setPullRequests: (pullRequests) => set({ pullRequests }),
+      setTeamMembers: (teamMembers) => set({ teamMembers }),
+      setSearchResults: (searchResults) => set({ searchResults }),
+      setIsLoadingUser: (isLoadingUser) => set({ isLoadingUser }),
+      setIsLoadingOrganizations: (isLoadingOrganizations) => set({ isLoadingOrganizations }),
+      setIsLoadingOrgResources: (isLoadingOrgResources) => set({ isLoadingOrgResources }),
+      setIsLoadingUserResources: (isLoadingUserResources) => set({ isLoadingUserResources }),
+      setIsLoadingTeamMembers: (isLoadingTeamMembers) => set({ isLoadingTeamMembers }),
+      setIsSearching: (isSearching) => set({ isSearching }),
+      setHasSearched: (hasSearched) => set({ hasSearched }),
+      setUserError: (userError) => set({ userError }),
+      setOrganizationsError: (organizationsError) => set({ organizationsError }),
+      setOrgResourcesError: (orgResourcesError) => set({ orgResourcesError }),
+      setUserResourcesError: (userResourcesError) => set({ userResourcesError }),
+      setTeamMembersError: (teamMembersError) => set({ teamMembersError }),
+      setSearchError: (searchError) => set({ searchError }),
+
+      resetSearchState: () => set({
+        searchResults: [],
+        isSearching: false,
+        hasSearched: false,
+        searchError: null
+      }),
+
+      resetOrgResourcesState: () => set({
+        repositories: [],
+        projects: [],
+        teams: [],
+        isLoadingOrgResources: false,
+        orgResourcesError: null
+      }),
+
+      resetUserResourcesState: () => set({
+        issues: [],
+        pullRequests: [],
+        isLoadingUserResources: false,
+        userResourcesError: null
+      }),
+
+      resetTeamMembersState: () => set({
+        teamMembers: [],
+        isLoadingTeamMembers: false,
+        teamMembersError: null
+      }),
+
+      // Tracked tickets actions
+      addTrackedTicket: (ticket) => set((state) => ({
+        trackedTickets: [ticket, ...state.trackedTickets].slice(0, 20)
+      })),
+      removeTrackedTicket: (ticketId) => set((state) => ({
+        trackedTickets: state.trackedTickets.filter(ticket => ticket.id !== ticketId)
+      })),
+      clearTrackedTickets: () => set({ trackedTickets: [] }),
+    }),
+    {
+      name: 'github-storage',
+      partialize: (state) => ({ trackedTickets: state.trackedTickets }),
+    }
+  )
+);

--- a/types/github.ts
+++ b/types/github.ts
@@ -1,0 +1,17 @@
+export interface Issue {
+    id: number;
+    number: number;
+    title: string;
+    html_url: string;
+    state: string;
+    updated_at: string;
+    repository_url: string;
+    user: {
+        login: string;
+        avatar_url?: string;
+    };
+    assignees?: {
+        login: string;
+        avatar_url?: string;
+    }[];
+} 


### PR DESCRIPTION
## Description
This PR introduces a new feature that allows users to track and manage their GitHub issues/tickets. Users can now bookmark issues they want to keep track of, and these tracked tickets are displayed in a separate panel alongside the search results.

## Changes
- Added a new `TicketHistory` component to display tracked tickets
- Implemented persistent storage for tracked tickets using Zustand's persist middleware
- Added bookmark functionality to track/untrack tickets
- Updated the main page layout to show search results and tracked tickets in a two-column layout
- Improved code organization by moving the Issue interface to a separate types file
- Added automatic tracking when starting time tracking for an issue

## Technical Details
- Used Zustand's persist middleware to maintain tracked tickets across sessions
- Limited tracked tickets to 20 items to prevent excessive storage usage
- Added new UI components for better user interaction (bookmark icons)
- Improved type safety by centralizing the Issue interface

## Screenshot
<img width="1916" alt="image" src="https://github.com/user-attachments/assets/4ebcc8cc-f40e-433f-b9cc-6feb2cec921f" />

