### PR TITLE
fix: timer drift accuracy

### DIFF
--- a/src/components/timer.tsx
+++ b/src/components/timer.tsx
@@ -22,6 +22,7 @@ export function Timer() {
     const [endSessionMessage, setEndSessionMessage] = useLocalStorage('end-session-message', "")
 
     const timerRef = useRef<NodeJS.Timeout>(null)
+    const startTimeRef = useRef<number | null>(null)
     const queryClient = useQueryClient()
     const { slug } = useParams({ from: "/space/$slug" })
 
@@ -107,21 +108,25 @@ export function Timer() {
     // Initialize timer state from active session
     React.useEffect(() => {
         if (activeSession) {
-            setIsRunning(true)
             const startTime = new Date(activeSession.started_at).getTime()
-            const now = new Date().getTime()
-            const elapsedSeconds = Math.floor((now - startTime) / 1000)
-            setTime(elapsedSeconds)
+            startTimeRef.current = startTime
+
+            setIsRunning(true)
+            setTime(Math.floor((Date.now() - startTime) / 1000))
         } else {
             setIsRunning(false)
             setTime(0)
+            startTimeRef.current = null
         }
     }, [activeSession])
 
     React.useEffect(() => {
         if (isRunning) {
             timerRef.current = setInterval(() => {
-                setTime((prevTime) => prevTime + 1)
+                if (startTimeRef.current !== null) {
+                    const now = Date.now()
+                    setTime(Math.floor((now - startTimeRef.current) / 1000))
+                }
             }, 1000)
         } else {
             if (timerRef.current) {


### PR DESCRIPTION
## Fix Timer Accuracy Issue

### Problem
The session timer was experiencing drift when the browser tab became inactive or was throttled. The timer was incrementing by +1 every second, but when the tab was backgrounded, those ticks were skipped, causing the displayed time to fall behind the actual elapsed session time.

### Root Cause
- Timer used incremental counter (`prevTime + 1`) instead of calculating from actual start time
- Browser throttles `setInterval` in background tabs, causing missed ticks
- Only on page refresh would the timer show correct time (recalculated from DB `started_at`)

### Solution
- **Store session start timestamp**: Added `startTimeRef` to maintain the actual session start time
- **Calculate exact elapsed time**: On each tick, compute `Date.now() - startTime` instead of incrementing
- **Handle session state**: Clear ref when no active session, recalculate on session load

### Changes
- Modified `src/components/timer.tsx`:
  - Added `startTimeRef` to store session start timestamp
  - Updated timer initialization to set ref and calculate initial elapsed time
  - Changed interval callback to recalculate exact elapsed seconds each tick
  - Added proper cleanup when session ends

### Testing
- ✅ Timer remains accurate when switching tabs
- ✅ Timer continues correctly after browser sleep/wake
- ✅ Timer shows correct time immediately after page refresh
- ✅ No impact on session creation/ending functionality

### Impact
- **User Experience**: Timer now shows accurate session duration regardless of tab activity
- **Data Integrity**: Session durations will be more accurate for reporting/analytics
- **Reliability**: Timer works consistently across different browser states