### PR TITLE
Add session start and end notifications

### DIFF
--- a/src/components/timer.tsx
+++ b/src/components/timer.tsx
@@ -1,109 +1,36 @@
 import * as React from "react"
 import { Button } from "@/components/ui/button"
 import { Square, Trash2 } from "lucide-react"
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import { getActiveSession, getSpaceAndTracks } from "@/lib/supabase/queries"
-import { endSession, linkTagToSession, deleteSession } from "@/lib/supabase/mutations"
-import { toast } from "sonner"
 import { useRef } from "react"
 import { useParams } from "@tanstack/react-router"
-import { createIssueComment } from "@/lib/github/mutations"
 import { EndSessionDialog } from "@/components/end-session-dialog"
 import { DiscardSessionDialog } from "@/components/discard-session-dialog"
-import type { Tag } from "@/types"
-import { formatSessionComment, getGitHubIssueUrl } from "@/lib/utils"
-import { useLocalStorage } from "@/hooks/use-local-storage"
+import { getGitHubIssueUrl } from "@/lib/utils"
+import { useSessions } from "@/hooks/api/use-sessions"
 
 export function Timer() {
     const [time, setTime] = React.useState(0)
     const [isRunning, setIsRunning] = React.useState(false)
-    const [showEndSessionDialog, setShowEndSessionDialog] = React.useState(false)
-    const [showDiscardDialog, setShowDiscardDialog] = React.useState(false)
-    const [endSessionMessage, setEndSessionMessage] = useLocalStorage('end-session-message', "")
 
     const timerRef = useRef<NodeJS.Timeout>(null)
     const startTimeRef = useRef<number | null>(null)
-    const queryClient = useQueryClient()
     const { slug } = useParams({ from: "/space/$slug" })
+    
+    const {
+        activeSession,
+        spaceData,
+        endSessionMutation,
+        discardSessionMutation,
+        handleEndSession,
+        handleDiscardSession,
+        endSessionMessage,
+        setEndSessionMessage,
+        showEndSessionDialog,
+        setShowEndSessionDialog,
+        showDiscardDialog,
+        setShowDiscardDialog
+    } = useSessions(slug)
 
-    // Get active session
-    const { data: activeSession } = useQuery({
-        queryKey: ["activeSession", slug],
-        queryFn: () => getActiveSession(),
-        enabled: !!slug,
-    })
-
-    // Get space data for space ID
-    const { data: spaceData } = useQuery({
-        queryKey: ["space", slug],
-        queryFn: () => getSpaceAndTracks(slug),
-        enabled: !!slug,
-    })
-
-    // End session mutation
-    const endSessionMutation = useMutation({
-        mutationFn: async ({ sessionId, message, skipSummary, selectedTags }: { sessionId: string, message: string, skipSummary: boolean, selectedTags: Tag[] }) => {
-            if (!activeSession?.track) throw new Error("No active track found")
-
-            // Calculate duration using proper Date objects
-            const startDate = new Date(activeSession.started_at)
-            const endDate = new Date()
-            const duration = endDate.getTime() - startDate.getTime()
-
-            let commentUrl: string | undefined
-            if (!skipSummary) {
-                // Create GitHub issue comment
-                const response = await createIssueComment({
-                    owner: activeSession.track.repo_owner,
-                    repo: activeSession.track.repo_name,
-                    issue_number: activeSession.track.issue_number,
-                    body: formatSessionComment(
-                        duration,
-                        message,
-                    )
-                })
-                commentUrl = response.html_url
-            }
-
-            // End the session and link tags
-            await endSession(sessionId, commentUrl, skipSummary, endDate.toISOString())
-
-            // Link selected tags to the session
-            for (const tag of selectedTags) {
-                await linkTagToSession(sessionId, tag.id)
-            }
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['activeSession', slug] })
-            queryClient.invalidateQueries({ queryKey: ['closedSessions', spaceData?.space?.id] })
-            setIsRunning(false)
-            setTime(0)
-            setShowEndSessionDialog(false)
-            setEndSessionMessage("")
-            toast.success("Session ended successfully")
-        },
-        onError: (error) => {
-            toast.error(`Failed to end session: ${error.message}`)
-        }
-    })
-
-    // Discard session mutation
-    const discardSessionMutation = useMutation({
-        mutationFn: async ({ sessionId }: { sessionId: string }) => {
-            await deleteSession(sessionId)
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['activeSession', slug] })
-            queryClient.invalidateQueries({ queryKey: ['closedSessions', spaceData?.space?.id] })
-            setIsRunning(false)
-            setTime(0)
-            setShowDiscardDialog(false)
-            toast.success("Session discarded successfully")
-        },
-        onError: (error) => {
-            toast.error(`Failed to discard session: ${error.message}`)
-        }
-    })
 
     // Initialize timer state from active session
     React.useEffect(() => {
@@ -147,22 +74,13 @@ export function Timer() {
         }
     }
 
-    const handleEndSession = (skipSummary: boolean, selectedTags: Tag[]) => {
-        if (activeSession && (endSessionMessage.trim() || skipSummary)) {
-            endSessionMutation.mutate({
-                sessionId: activeSession.id,
-                message: endSessionMessage.trim(),
-                skipSummary,
-                selectedTags
-            })
+    // Update timer state when session ends
+    React.useEffect(() => {
+        if (endSessionMutation.isSuccess || discardSessionMutation.isSuccess) {
+            setIsRunning(false)
+            setTime(0)
         }
-    }
-
-    const handleDiscardSession = () => {
-        if (activeSession) {
-            discardSessionMutation.mutate({ sessionId: activeSession.id })
-        }
-    }
+    }, [endSessionMutation.isSuccess, discardSessionMutation.isSuccess])
 
     const formatTime = (seconds: number) => {
         const hours = Math.floor(seconds / 3600)

--- a/src/hooks/api/use-sessions.ts
+++ b/src/hooks/api/use-sessions.ts
@@ -20,6 +20,8 @@ import { useLocalStorage } from "@/hooks/use-local-storage";
 import { toast } from "sonner";
 import { formatSessionComment, formatTime } from "@/lib/utils";
 import { DEBOUNCE_TIME } from "@/constants";
+import { notifySessionEvent } from "@/lib/notifications/utils";
+import { useAuth } from "@/hooks/api/use-auth";
 import type { GitHubIssue, Tag } from "@/types";
 
 export function useSessions(slug: string) {
@@ -38,6 +40,7 @@ export function useSessions(slug: string) {
   const [timeFilter, setTimeFilter] = useState<"all" | "day" | "week">("all");
   const [sessionLimit, setSessionLimit] = useState<number>(10);
   const queryClient = useQueryClient();
+  const { user } = useAuth();
 
   const { data: spaceData, isLoading: isLoadingSpace } = useQuery({
     queryKey: ["space", slug],
@@ -109,6 +112,15 @@ export function useSessions(slug: string) {
       for (const tag of selectedTags) {
         await linkTagToSession(sessionId, tag.id);
       }
+      
+      // Send notification
+      if (user) {
+        await notifySessionEvent(user, {
+          type: 'end',
+          trackTitle: activeSession.track.title || 'Untitled Track',
+          duration: duration,
+        });
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["activeSession", slug] });
@@ -149,10 +161,23 @@ export function useSessions(slug: string) {
   const startSessionMutation = useMutation({
     mutationFn: async (trackId: string) => {
       if (!spaceData?.space_member) return;
-      await createSession({
+      const session = await createSession({
         track_id: trackId,
         space_member_id: spaceData.space_member.id,
       });
+      
+      // Send notification
+      if (user && spaceData?.tracks) {
+        const track = spaceData.tracks.find(t => t.id === trackId);
+        if (track) {
+          await notifySessionEvent(user, {
+            type: 'start',
+            trackTitle: track.title || 'Untitled Track',
+          });
+        }
+      }
+      
+      return session;
     },
     onSuccess: () => {
       setSearchQuery("");
@@ -193,6 +218,14 @@ export function useSessions(slug: string) {
         track_id: track.id,
         space_member_id: spaceData.space_member.id,
       });
+
+      // Send notification
+      if (user && track) {
+        await notifySessionEvent(user, {
+          type: 'start',
+          trackTitle: track.title || 'Untitled Track',
+        });
+      }
 
       return track;
     },

--- a/src/hooks/api/use-tracks.ts
+++ b/src/hooks/api/use-tracks.ts
@@ -1,11 +1,9 @@
 import { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { createTrack, createSession } from "@/lib/supabase/mutations";
+import { useQuery } from "@tanstack/react-query";
 import { getSpaceAndTracks } from "@/lib/supabase/queries";
 import { searchIssues } from "@/lib/github/queries";
 import type { GitHubIssue } from "@/types";
 import { useDebounce } from "@/hooks/use-debounce";
-import { toast } from "sonner";
 import { DEBOUNCE_TIME } from "@/constants";
 
 export function useTracks(slug: string) {
@@ -14,7 +12,6 @@ export function useTracks(slug: string) {
     searchQuery,
     DEBOUNCE_TIME
   );
-  const queryClient = useQueryClient();
 
   const { data: spaceData, isLoading } = useQuery({
     queryKey: ["space", slug],
@@ -32,35 +29,6 @@ export function useTracks(slug: string) {
     retry: false,
   });
 
-  const createTrackMutation = useMutation({
-    mutationFn: async (issue: GitHubIssue) => {
-      if (!spaceData?.space || !issue.repository) return;
-      if (!spaceData.space_member) throw new Error("space_member is null");
-
-      const track = await createTrack({
-        space_id: spaceData.space.id,
-        repo_owner: issue.repository.owner || "",
-        repo_name: issue.repository.name || "",
-        issue_number: issue.number,
-        title: issue.title,
-      });
-
-      await createSession({
-        track_id: track.id,
-        space_member_id: spaceData.space_member.id,
-      });
-
-      return track;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["space", slug] });
-      setSearchQuery("");
-      toast.success("Track created and session started");
-    },
-    onError: (error) => {
-      toast.error(`Failed to create track: ${error.message}`);
-    },
-  });
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -86,7 +54,6 @@ export function useTracks(slug: string) {
     isSearching,
     searchError,
     tracks: spaceData?.tracks || [],
-    createTrackMutation,
     handleSearch,
     isTracked,
   };

--- a/src/lib/notifications/utils.ts
+++ b/src/lib/notifications/utils.ts
@@ -1,4 +1,5 @@
 import { sendGoogleChatNotification } from './webhook'
+import { formatTime } from '@/lib/utils'
 import type { User } from '@supabase/supabase-js'
 
 export type StatusUpdate = {
@@ -43,22 +44,8 @@ export function formatSessionMessage(user: User | null, event: SessionEvent): st
     if (event.type === 'start') {
         return `*${full_name}* started working on: ${trackTitle}`
     } else {
-        const durationText = event.duration ? ` (${formatDuration(event.duration)})` : ''
+        const durationText = event.duration ? ` (${formatTime(event.duration)})` : ''
         return `*${full_name}* finished working on: ${trackTitle}${durationText}`
-    }
-}
-
-function formatDuration(milliseconds: number): string {
-    const seconds = Math.floor(milliseconds / 1000)
-    const minutes = Math.floor(seconds / 60)
-    const hours = Math.floor(minutes / 60)
-    
-    if (hours > 0) {
-        return `${hours}h ${minutes % 60}m`
-    } else if (minutes > 0) {
-        return `${minutes}m`
-    } else {
-        return `${seconds}s`
     }
 }
 

--- a/src/lib/notifications/utils.ts
+++ b/src/lib/notifications/utils.ts
@@ -6,6 +6,16 @@ export type StatusUpdate = {
     location: string
 }
 
+export type SessionEvent = {
+    type: 'start' | 'end'
+    trackTitle: string
+    duration?: number
+}
+
+export type NotificationEvent = 
+    | { type: 'status_update'; data: StatusUpdate }
+    | { type: 'session_event'; data: SessionEvent }
+
 export function formatStatusMessage(user: User | null, update: StatusUpdate): string {
     if (!user?.user_metadata?.full_name) {
         return 'Unknown user updated their status'
@@ -22,11 +32,61 @@ export function formatStatusMessage(user: User | null, update: StatusUpdate): st
     return `*${full_name}* is now ${status} and ${location}`
 }
 
-export async function notifyStatusUpdate(user: User | null, update: StatusUpdate) {
+export function formatSessionMessage(user: User | null, event: SessionEvent): string {
+    if (!user?.user_metadata?.full_name) {
+        return 'Unknown user session activity'
+    }
+
+    const full_name = user.user_metadata.full_name.trim()
+    const trackTitle = event.trackTitle.length > 50 ? `${event.trackTitle.substring(0, 50)}...` : event.trackTitle
+
+    if (event.type === 'start') {
+        return `*${full_name}* started working on: ${trackTitle}`
+    } else {
+        const durationText = event.duration ? ` (${formatDuration(event.duration)})` : ''
+        return `*${full_name}* finished working on: ${trackTitle}${durationText}`
+    }
+}
+
+function formatDuration(milliseconds: number): string {
+    const seconds = Math.floor(milliseconds / 1000)
+    const minutes = Math.floor(seconds / 60)
+    const hours = Math.floor(minutes / 60)
+    
+    if (hours > 0) {
+        return `${hours}h ${minutes % 60}m`
+    } else if (minutes > 0) {
+        return `${minutes}m`
+    } else {
+        return `${seconds}s`
+    }
+}
+
+export async function sendNotification(user: User | null, event: NotificationEvent) {
     try {
-        const message = formatStatusMessage(user, update)
+        let message: string
+        
+        switch (event.type) {
+            case 'status_update':
+                message = formatStatusMessage(user, event.data)
+                break
+            case 'session_event':
+                message = formatSessionMessage(user, event.data)
+                break
+            default:
+                throw new Error('Unknown notification event type')
+        }
+        
         await sendGoogleChatNotification(message)
     } catch (error) {
-        console.error('Failed to send status update notification:', error)
+        console.error('Failed to send notification:', error)
     }
+}
+
+export async function notifyStatusUpdate(user: User | null, update: StatusUpdate) {
+    await sendNotification(user, { type: 'status_update', data: update })
+}
+
+export async function notifySessionEvent(user: User | null, event: SessionEvent) {
+    await sendNotification(user, { type: 'session_event', data: event })
 } 

--- a/src/lib/supabase/mutations.ts
+++ b/src/lib/supabase/mutations.ts
@@ -1,6 +1,5 @@
 import { getSupabaseClient } from "@/lib/supabase/client";
 import { getUser } from "./queries";
-import { notifySessionEvent } from "@/lib/notifications/utils";
 import type { Tag } from "@/types";
 import type { User } from "@supabase/supabase-js";
 
@@ -169,15 +168,7 @@ export async function createSession({
     );
   }
 
-  // 4. Get track details for notification
-  const { data: track, error: trackError } = await supabase
-    .from("tracks")
-    .select("title")
-    .eq("id", track_id)
-    .single();
-  if (trackError) throw new Error(trackError.message);
-
-  // 5. Create the new session
+  // 4. Create the new session
   const { data, error } = await supabase
     .from("sessions")
     .insert({
@@ -188,20 +179,6 @@ export async function createSession({
     .select()
     .single();
   if (error) throw new Error(error.message);
-
-  // 6. Send notification
-  try {
-    const user = await getUser();
-    if (user) {
-      await notifySessionEvent(user, {
-        type: 'start',
-        trackTitle: track.title,
-      });
-    }
-  } catch (notificationError) {
-    console.error('Failed to send session start notification:', notificationError);
-  }
-
   return data;
 }
 
@@ -211,15 +188,6 @@ export async function endSession(
   skip_summary?: boolean,
   ended_at: string = new Date().toISOString()
 ) {
-  // 1. Get session details for notification
-  const { data: session, error: sessionError } = await supabase
-    .from("sessions")
-    .select("started_at, tracks!inner(title)")
-    .eq("id", session_id)
-    .single();
-  if (sessionError) throw new Error(sessionError.message);
-
-  // 2. Update the session
   const { data, error } = await supabase
     .from("sessions")
     .update({
@@ -231,25 +199,6 @@ export async function endSession(
     .select()
     .single();
   if (error) throw new Error(error.message);
-
-  // 3. Send notification
-  try {
-    const user = await getUser();
-    if (user) {
-      const startTime = new Date(session.started_at).getTime();
-      const endTime = new Date(ended_at).getTime();
-      const duration = endTime - startTime;
-
-      await notifySessionEvent(user, {
-        type: 'end',
-        trackTitle: (session.tracks as any).title,
-        duration: duration,
-      });
-    }
-  } catch (notificationError) {
-    console.error('Failed to send session end notification:', notificationError);
-  }
-
   return data;
 }
 

--- a/src/lib/supabase/mutations.ts
+++ b/src/lib/supabase/mutations.ts
@@ -1,5 +1,6 @@
 import { getSupabaseClient } from "@/lib/supabase/client";
 import { getUser } from "./queries";
+import { notifySessionEvent } from "@/lib/notifications/utils";
 import type { Tag } from "@/types";
 import type { User } from "@supabase/supabase-js";
 
@@ -168,7 +169,15 @@ export async function createSession({
     );
   }
 
-  // 4. Create the new session
+  // 4. Get track details for notification
+  const { data: track, error: trackError } = await supabase
+    .from("tracks")
+    .select("title")
+    .eq("id", track_id)
+    .single();
+  if (trackError) throw new Error(trackError.message);
+
+  // 5. Create the new session
   const { data, error } = await supabase
     .from("sessions")
     .insert({
@@ -179,6 +188,20 @@ export async function createSession({
     .select()
     .single();
   if (error) throw new Error(error.message);
+
+  // 6. Send notification
+  try {
+    const user = await getUser();
+    if (user) {
+      await notifySessionEvent(user, {
+        type: 'start',
+        trackTitle: track.title,
+      });
+    }
+  } catch (notificationError) {
+    console.error('Failed to send session start notification:', notificationError);
+  }
+
   return data;
 }
 
@@ -188,6 +211,15 @@ export async function endSession(
   skip_summary?: boolean,
   ended_at: string = new Date().toISOString()
 ) {
+  // 1. Get session details for notification
+  const { data: session, error: sessionError } = await supabase
+    .from("sessions")
+    .select("started_at, tracks!inner(title)")
+    .eq("id", session_id)
+    .single();
+  if (sessionError) throw new Error(sessionError.message);
+
+  // 2. Update the session
   const { data, error } = await supabase
     .from("sessions")
     .update({
@@ -199,6 +231,25 @@ export async function endSession(
     .select()
     .single();
   if (error) throw new Error(error.message);
+
+  // 3. Send notification
+  try {
+    const user = await getUser();
+    if (user) {
+      const startTime = new Date(session.started_at).getTime();
+      const endTime = new Date(ended_at).getTime();
+      const duration = endTime - startTime;
+
+      await notifySessionEvent(user, {
+        type: 'end',
+        trackTitle: (session.tracks as any).title,
+        duration: duration,
+      });
+    }
+  } catch (notificationError) {
+    console.error('Failed to send session end notification:', notificationError);
+  }
+
   return data;
 }
 

--- a/src/routes/space/$slug/tracks/index.tsx
+++ b/src/routes/space/$slug/tracks/index.tsx
@@ -4,6 +4,7 @@ import type { Track } from '@/types'
 import { TracksListSkeleton } from '@/components/skeleton/tracks-list-skeleton'
 import { SearchForm } from '@/components/search-form'
 import { useTracks } from '@/hooks/api/use-tracks'
+import { useSessions } from '@/hooks/api/use-sessions'
 
 export const Route = createFileRoute('/space/$slug/tracks/')({
     component: TracksPage,
@@ -22,10 +23,11 @@ function TracksPage() {
         isSearching,
         searchError,
         tracks,
-        createTrackMutation,
         handleSearch,
         isTracked,
     } = useTracks(slug)
+    
+    const { createTrackAndStartSessionMutation } = useSessions(slug)
 
     if (isLoading) {
         return <TracksListSkeleton />
@@ -41,7 +43,7 @@ function TracksPage() {
                 onSearchQueryChange={setSearchQuery}
                 onSubmit={handleSearch}
                 isSearching={isSearching}
-                isDisabled={createTrackMutation.isPending}
+                isDisabled={createTrackAndStartSessionMutation.isPending}
                 error={searchError}
             />
 
@@ -68,11 +70,11 @@ function TracksPage() {
                                         </span>
                                     ) : (
                                         <button
-                                            onClick={() => createTrackMutation.mutate(issue)}
-                                            disabled={createTrackMutation.isPending}
+                                            onClick={() => createTrackAndStartSessionMutation.mutate(issue)}
+                                            disabled={createTrackAndStartSessionMutation.isPending}
                                             className="px-4 py-2 text-sm text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 whitespace-nowrap"
                                         >
-                                            {createTrackMutation.isPending ? 'Creating...' : 'Track Issue'}
+                                            {createTrackAndStartSessionMutation.isPending ? 'Creating...' : 'Track Issue'}
                                         </button>
                                     )}
                                 </div>


### PR DESCRIPTION
Introduce notifications for session start and end events, enhancing user awareness of their activity. The implementation includes formatting messages and sending notifications through the existing notification system.

example of the new notifications:
```
Ahmed Rian started working on: [ Customer ] [ Integration ] - Reintegrate auth fl...
Ahmed Rian finished working on: [ Customer ] [ Integration ] - Reintegrate auth fl... (17m)
```