### PR TITLE
fix: resolve TypeScript errors in session change requests feature

### DIFF
--- a/src/components/sidebars/space-sidebar.tsx
+++ b/src/components/sidebars/space-sidebar.tsx
@@ -109,7 +109,7 @@ export function SpaceSidebar({ space, ...props }: React.ComponentProps<typeof Si
     }, [space]);
 
     const filteredSidebarMenu = React.useMemo(() => {
-        return sidebarMenu.filter(item => {
+        return sidebarMenu.filter(() => {
             // Show all menu items to all space members
             return true;
         });

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -9,7 +9,6 @@ import type {
   ClosedSession,
   ActiveSession,
 } from "@/types";
-import type { Database } from "@/types/database.types";
 
 const supabase = getSupabaseClient();
 

--- a/src/routes/space/$slug/change-requests/index.tsx
+++ b/src/routes/space/$slug/change-requests/index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { getSpaceAndTracks } from '@/lib/supabase/queries'
-import { getCurrentUserSpaceRole } from '@/hooks/api/use-space-role'
 import { useSessionChangeRequests } from '@/hooks/api/use-session-change-requests'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -17,7 +16,6 @@ export const Route = createFileRoute('/space/$slug/change-requests/')({
 })
 
 function ChangeRequestsPage() {
-    const { slug } = Route.useParams()
     const spaceData = Route.useLoaderData()
     const space = spaceData?.space
     const [filter, setFilter] = useState<'all' | 'pending' | 'approved' | 'rejected'>('all')


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation errors that were preventing the build from succeeding after the session duration change request feature was merged.

## Issues Fixed

- **space-sidebar.tsx**: Removed unused  parameter from filter function
- **queries.ts**: Removed unused  type import  
- **change-requests/index.tsx**: Removed unused  import and  variable

## Changes Made

1. Updated filter function to use anonymous parameter  instead of unused  parameter
2. Cleaned up import statements by removing unused type imports
3. Removed unused variables that were causing TS6133 errors

## Testing

- ✅ Build passes successfully with 
> agilespace@0.0.0 build /Users/atito/Workspace/AgileSpace/agilespace
> tsc -b && vite build

vite v6.3.5 building for production...
Generated route tree in 90ms
transforming...
✓ 3726 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     1.03 kB │ gzip:   0.47 kB
dist/assets/index-D1bPo4Bs.css    136.02 kB │ gzip:  22.20 kB
dist/assets/index-b0esa7pB.js   2,449.38 kB │ gzip: 758.65 kB
✓ built in 2.94s
- ✅ TypeScript compilation completes without errors
- ✅ All functionality remains intact

## Impact

This is a purely maintenance fix with no functional changes - only resolving TypeScript linting issues that were blocking the build process.

🤖 Generated with [Claude Code](https://claude.ai/code)