### PR TITLE
feat: enhance change requests with member filters and reviewer display

### DIFF
--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -744,6 +744,25 @@ export const getSessionChangeRequests = async (spaceId: string) => {
     ]),
   ];
 
+  // Early return if no user IDs to avoid empty .in() query
+  if (uniqueUserIds.length === 0) {
+    return data.map((request) => ({
+      ...request,
+      reviewer_profile: null,
+      session: request.session
+        ? {
+            ...request.session,
+            space_member: request.session.space_member
+              ? {
+                  ...request.session.space_member,
+                  profile: null,
+                }
+              : null,
+          }
+        : null,
+    }));
+  }
+
   // Fetch profiles for all unique users
   const { data: profiles, error: profilesError } = await supabase
     .from("profiles")

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -730,7 +730,53 @@ export const getSessionChangeRequests = async (spaceId: string) => {
     .order("created_at", { ascending: false });
 
   if (error) throw new Error(error.message);
-  return data || [];
+  if (!data) return [];
+
+  // Get unique user IDs from space members and reviewers
+  const uniqueUserIds = [
+    ...new Set([
+      ...data
+        .map((request) => request.session?.space_member?.user_id)
+        .filter((id): id is string => id !== null),
+      ...data
+        .map((request) => request.reviewed_by)
+        .filter((id): id is string => id !== null)
+    ]),
+  ];
+
+  // Fetch profiles for all unique users
+  const { data: profiles, error: profilesError } = await supabase
+    .from("profiles")
+    .select("id, full_name, avatar_url")
+    .in("id", uniqueUserIds);
+
+  if (profilesError) throw new Error(profilesError.message);
+
+  // Create a map of user IDs to profiles for quick lookup
+  const profileMap = new Map(
+    (profiles || []).map((profile) => [profile.id, profile])
+  );
+
+  // Combine the data
+  return data.map((request) => ({
+    ...request,
+    reviewer_profile: request.reviewed_by
+      ? profileMap.get(request.reviewed_by)
+      : null,
+    session: request.session
+      ? {
+          ...request.session,
+          space_member: request.session.space_member
+            ? {
+                ...request.session.space_member,
+                profile: request.session.space_member.user_id
+                  ? profileMap.get(request.session.space_member.user_id)
+                  : null,
+              }
+            : null,
+        }
+      : null,
+  }));
 };
 
 export const getSessionChangeRequest = async (requestId: string) => {

--- a/src/routes/space/$slug/change-requests/index.tsx
+++ b/src/routes/space/$slug/change-requests/index.tsx
@@ -4,9 +4,16 @@ import { useSessionChangeRequests } from '@/hooks/api/use-session-change-request
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { format } from 'date-fns'
-import { Check, X, Clock, User } from 'lucide-react'
-import { useState } from 'react'
+import { Check, X, Clock, User, Filter, UserCheck } from 'lucide-react'
+import { useState, useMemo } from 'react'
 import { cn } from '@/lib/utils'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 
 export const Route = createFileRoute('/space/$slug/change-requests/')({
     component: ChangeRequestsPage,
@@ -19,6 +26,8 @@ function ChangeRequestsPage() {
     const spaceData = Route.useLoaderData()
     const space = spaceData?.space
     const [filter, setFilter] = useState<'all' | 'pending' | 'approved' | 'rejected'>('all')
+    const [requesterFilter, setRequesterFilter] = useState<string>('all')
+    const [reviewerFilter, setReviewerFilter] = useState<string>('all')
     
     const {
         changeRequests,
@@ -29,9 +38,48 @@ function ChangeRequestsPage() {
         isRejecting
     } = useSessionChangeRequests(space?.id || '')
 
+    // Get unique requesters and reviewers for filter dropdowns
+    const uniqueRequesters = useMemo(() => {
+        const requesters = changeRequests
+            .map(request => ({
+                id: request.session?.space_member?.user_id,
+                name: request.session?.space_member?.profile?.full_name
+            }))
+            .filter((requester): requester is { id: string; name: string } => 
+                !!requester.id && !!requester.name
+            )
+        
+        // Remove duplicates
+        const uniqueMap = new Map(requesters.map(r => [r.id, r]))
+        return Array.from(uniqueMap.values())
+    }, [changeRequests])
+
+    const uniqueReviewers = useMemo(() => {
+        const reviewers = changeRequests
+            .map(request => ({
+                id: request.reviewed_by,
+                name: request.reviewer_profile?.full_name
+            }))
+            .filter((reviewer): reviewer is { id: string; name: string } => 
+                !!reviewer.id && !!reviewer.name
+            )
+        
+        // Remove duplicates
+        const uniqueMap = new Map(reviewers.map(r => [r.id, r]))
+        return Array.from(uniqueMap.values())
+    }, [changeRequests])
+
     const filteredRequests = changeRequests.filter(request => {
-        if (filter === 'all') return true
-        return request.status === filter
+        // Status filter
+        if (filter !== 'all' && request.status !== filter) return false
+        
+        // Requester filter
+        if (requesterFilter !== 'all' && request.session?.space_member?.user_id !== requesterFilter) return false
+        
+        // Reviewer filter
+        if (reviewerFilter !== 'all' && request.reviewed_by !== reviewerFilter) return false
+        
+        return true
     })
 
     const getStatusBadgeVariant = (status: string) => {
@@ -78,7 +126,7 @@ function ChangeRequestsPage() {
                 {['all', 'pending', 'approved', 'rejected'].map((status) => (
                     <button
                         key={status}
-                        onClick={() => setFilter(status as any)}
+                        onClick={() => setFilter(status as 'all' | 'pending' | 'approved' | 'rejected')}
                         className={cn(
                             "px-4 py-2 text-sm font-medium border-b-2 transition-colors",
                             filter === status
@@ -94,6 +142,62 @@ function ChangeRequestsPage() {
                         )}
                     </button>
                 ))}
+            </div>
+
+            {/* Additional Filters */}
+            <div className="flex flex-wrap gap-4 items-center">
+                <div className="flex items-center gap-2">
+                    <Filter className="h-4 w-4 text-muted-foreground" />
+                    <span className="text-sm font-medium text-muted-foreground">Filters:</span>
+                </div>
+                
+                <div className="flex items-center gap-2">
+                    <User className="h-4 w-4 text-muted-foreground" />
+                    <Select value={requesterFilter} onValueChange={setRequesterFilter}>
+                        <SelectTrigger className="w-[200px]">
+                            <SelectValue placeholder="Filter by requester" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">All requesters</SelectItem>
+                            {uniqueRequesters.map((requester) => (
+                                <SelectItem key={requester.id} value={requester.id}>
+                                    {requester.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <UserCheck className="h-4 w-4 text-muted-foreground" />
+                    <Select value={reviewerFilter} onValueChange={setReviewerFilter}>
+                        <SelectTrigger className="w-[200px]">
+                            <SelectValue placeholder="Filter by reviewer" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">All reviewers</SelectItem>
+                            {uniqueReviewers.map((reviewer) => (
+                                <SelectItem key={reviewer.id} value={reviewer.id}>
+                                    {reviewer.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {/* Clear filters button */}
+                {(requesterFilter !== 'all' || reviewerFilter !== 'all') && (
+                    <Button 
+                        variant="outline" 
+                        size="sm"
+                        onClick={() => {
+                            setRequesterFilter('all')
+                            setReviewerFilter('all')
+                        }}
+                    >
+                        Clear filters
+                    </Button>
+                )}
             </div>
 
             {/* Change Requests List */}
@@ -129,7 +233,7 @@ function ChangeRequestsPage() {
                                     </div>
                                     <div className="flex items-center gap-2 text-sm text-muted-foreground">
                                         <User className="h-4 w-4" />
-                                        <span>Requested by {request.session?.space_member?.nickname || 'Unknown'}</span>
+                                        <span>Requested by {request.session?.space_member?.profile?.full_name || 'Unknown'}</span>
                                         <span>•</span>
                                         <span>{format(new Date(request.created_at || ''), 'MMM dd, yyyy HH:mm')}</span>
                                     </div>
@@ -202,7 +306,8 @@ function ChangeRequestsPage() {
                             {request.status !== 'pending' && request.reviewed_by && request.reviewed_at && (
                                 <div className="pt-4 border-t text-sm text-muted-foreground">
                                     <p>
-                                        {request.status === 'approved' ? 'Approved' : 'Rejected'} on{' '}
+                                        {request.status === 'approved' ? 'Approved' : 'Rejected'} by{' '}
+                                        {request.reviewer_profile?.full_name || 'Unknown'} on{' '}
                                         {format(new Date(request.reviewed_at), 'MMM dd, yyyy HH:mm')}
                                     </p>
                                 </div>

--- a/src/routes/space/$slug/change-requests/index.tsx
+++ b/src/routes/space/$slug/change-requests/index.tsx
@@ -39,34 +39,30 @@ function ChangeRequestsPage() {
     } = useSessionChangeRequests(space?.id || '')
 
     // Get unique requesters and reviewers for filter dropdowns
-    const uniqueRequesters = useMemo(() => {
-        const requesters = changeRequests
-            .map(request => ({
-                id: request.session?.space_member?.user_id,
-                name: request.session?.space_member?.profile?.full_name
-            }))
-            .filter((requester): requester is { id: string; name: string } => 
-                !!requester.id && !!requester.name
-            )
+    const { uniqueRequesters, uniqueReviewers } = useMemo(() => {
+        const requesterMap = new Map<string, { id: string; name: string }>()
+        const reviewerMap = new Map<string, { id: string; name: string }>()
         
-        // Remove duplicates
-        const uniqueMap = new Map(requesters.map(r => [r.id, r]))
-        return Array.from(uniqueMap.values())
-    }, [changeRequests])
-
-    const uniqueReviewers = useMemo(() => {
-        const reviewers = changeRequests
-            .map(request => ({
-                id: request.reviewed_by,
-                name: request.reviewer_profile?.full_name
-            }))
-            .filter((reviewer): reviewer is { id: string; name: string } => 
-                !!reviewer.id && !!reviewer.name
-            )
+        for (const request of changeRequests) {
+            // Process requesters
+            const requesterId = request.session?.space_member?.user_id
+            const requesterName = request.session?.space_member?.profile?.full_name
+            if (requesterId && requesterName) {
+                requesterMap.set(requesterId, { id: requesterId, name: requesterName })
+            }
+            
+            // Process reviewers
+            const reviewerId = request.reviewed_by
+            const reviewerName = request.reviewer_profile?.full_name
+            if (reviewerId && reviewerName) {
+                reviewerMap.set(reviewerId, { id: reviewerId, name: reviewerName })
+            }
+        }
         
-        // Remove duplicates
-        const uniqueMap = new Map(reviewers.map(r => [r.id, r]))
-        return Array.from(uniqueMap.values())
+        return {
+            uniqueRequesters: Array.from(requesterMap.values()),
+            uniqueReviewers: Array.from(reviewerMap.values())
+        }
     }, [changeRequests])
 
     const filteredRequests = changeRequests.filter(request => {


### PR DESCRIPTION
## Summary
- Add requester and reviewer filter dropdowns to the change requests page
- Display reviewer name in approved/rejected request cards  
- Fix member name display issues by updating query to include profile data
- Add clear filters functionality for better user experience

## Changes Made
- **Enhanced Query**: Updated `getSessionChangeRequests` to fetch profile data for both requesters and reviewers
- **New Filters**: Added dropdown filters to filter by requester and reviewer
- **Reviewer Display**: Show who approved/rejected each request in the card footer
- **Improved UX**: Added clear filters button and better data structure
- **Type Safety**: Fixed TypeScript errors with proper type annotations

## Screenshots
The change requests page now includes:
- Status filter tabs (existing)
- New requester and reviewer filter dropdowns
- Clear filters button when filters are active
- Enhanced request cards showing "Approved by [Name]" or "Rejected by [Name]"

## Test Plan
- [x] Verify change requests page loads without errors
- [x] Test filtering by requester works correctly
- [x] Test filtering by reviewer works correctly 
- [x] Test combined filtering (status + requester + reviewer)
- [x] Verify clear filters button functionality
- [x] Confirm reviewer names display in approved/rejected cards
- [x] TypeScript compilation passes without errors
- [x] Build process completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)